### PR TITLE
add GetCheckpoint to LES (status.im issue 320)

### DIFF
--- a/les/backend.go
+++ b/les/backend.go
@@ -77,6 +77,10 @@ type LightEthereum struct {
 	wg sync.WaitGroup
 }
 
+func (f LightEthereum) LesOdr() *LesOdr {
+	return f.odr
+}
+
 func New(ctx *node.ServiceContext, config *eth.Config) (*LightEthereum, error) {
 	chainDb, err := eth.CreateDB(ctx, config, "lightchaindata")
 	if err != nil {

--- a/les/backend.go
+++ b/les/backend.go
@@ -77,10 +77,6 @@ type LightEthereum struct {
 	wg sync.WaitGroup
 }
 
-func (f LightEthereum) LesOdr() *LesOdr {
-	return f.odr
-}
-
 func New(ctx *node.ServiceContext, config *eth.Config) (*LightEthereum, error) {
 	chainDb, err := eth.CreateDB(ctx, config, "lightchaindata")
 	if err != nil {

--- a/les/odr.go
+++ b/les/odr.go
@@ -77,6 +77,7 @@ const (
 	MsgProofsV2
 	MsgHeaderProofs
 	MsgHelperTrieProofs
+	MsgCheckpoint
 )
 
 // Msg encodes a LES message that delivers reply data for a request

--- a/les/peer.go
+++ b/les/peer.go
@@ -325,6 +325,25 @@ func (p *peer) SendTxs(reqID, cost uint64, txs types.Transactions) error {
 	}
 }
 
+// RequestCheckpoint a checkpoint at the specified section index from a remote node.
+func (p *peer) RequestCheckpoint(reqID, cost uint64, req CheckpointReq) error {
+	p.Log().Debug("Fetching checkpoint", "req", req, "p.version", p.version, "lpv1", lpv1)
+	switch p.version {
+	case lpv1:
+		p.Log().Info("RequestCheckpoint: lpv1 so doing nothing")
+		return nil
+	case lpv2:
+		return sendRequest(p.rw, GetCheckpointMsg, reqID, cost, req)
+	default:
+		panic(nil)
+	}
+}
+
+// SendCheckpoint sends a checkpoint, corresponding to the one requested.
+func (p *peer) SendCheckpoint(reqID, bv uint64, roots [3]common.Hash) error {
+	return sendResponse(p.rw, CheckpointMsg, reqID, bv, roots)
+}
+
 type keyValueEntry struct {
 	Key   string
 	Value rlp.RawValue

--- a/les/protocol.go
+++ b/les/protocol.go
@@ -46,7 +46,7 @@ var (
 )
 
 // Number of implemented message corresponding to different protocol versions.
-var ProtocolLengths = map[uint]uint64{lpv1: 15, lpv2: 22}
+var ProtocolLengths = map[uint]uint64{lpv1: 15, lpv2: 24}
 
 const (
 	NetworkId          = 1
@@ -79,6 +79,8 @@ const (
 	SendTxV2Msg            = 0x13
 	GetTxStatusMsg         = 0x14
 	TxStatusMsg            = 0x15
+	GetCheckpointMsg       = 0x16
+	CheckpointMsg          = 0x17
 )
 
 type errCode int

--- a/les/sync.go
+++ b/les/sync.go
@@ -79,7 +79,7 @@ func (pm *ProtocolManager) synchronise(peer *peer) {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 	updateChtFromPeer(pm, peer, ctx)
 	pm.blockchain.(*light.LightChain).SyncCht(ctx)

--- a/les/sync.go
+++ b/les/sync.go
@@ -20,9 +20,11 @@ import (
 	"context"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/eth/downloader"
 	"github.com/ethereum/go-ethereum/light"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 const (
@@ -77,8 +79,37 @@ func (pm *ProtocolManager) synchronise(peer *peer) {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()
+	updateChtFromPeer(pm, peer, ctx)
 	pm.blockchain.(*light.LightChain).SyncCht(ctx)
 	pm.downloader.Synchronise(peer.id, peer.Head(), peer.Td(), downloader.LightSync)
+}
+
+// Status.im issue 320: Use GetHeaderProofs to download the latest CHT from a peer.
+func updateChtFromPeer(pm *ProtocolManager, peer *peer, ctx context.Context) {
+	log.Info("Downloading latest CHT root from peer", "peer.headBlockInfo", peer.headBlockInfo())
+
+	// Formula from lightchain.go:SyncCht: num := cht.Number*ChtFrequency – 1
+	var hbl = peer.headBlockInfo()
+	var peerHeadBlockNum = hbl.Number
+	log.Debug("UpdateChtFromPeer", "peerHeadBlockNum", peerHeadBlockNum)
+
+	var sectionIdx uint64 = ((peerHeadBlockNum + 1) / light.ChtFrequency) - 1
+	log.Debug("Retrieving checkpoint with: ", "sectionIdx", sectionIdx)
+
+	req := &light.CheckpointRequest{SectionIdx: uint64(sectionIdx)}
+	pm.odr.Retrieve(ctx, req)
+	log.Info("Retrieved checkpoint from peer: ",
+		"SectionHead=", common.ToHex(req.SectionHead.Bytes()),
+		"ChtRoot", common.ToHex(req.ChtRoot.Bytes()),
+		"BloomTrieRoot", common.ToHex(req.BloomRoot.Bytes()))
+
+	pm.blockchain.(*light.LightChain).AddTrustedCheckpoint("live", sectionIdx, req.SectionHead, req.ChtRoot, req.BloomRoot)
+	log.Debug("Added checkpoint to LightChain")
+
+	log.Info("Sanity check: can download some very old header?")
+	var sanityBlock uint64 = hbl.Number / 100
+	sanityHeader, err := pm.blockchain.(*light.LightChain).GetHeaderByNumberOdr(ctx, sanityBlock)
+	log.Info("Sanity check result:", "sanityHeader", sanityHeader, "err", err)
 }

--- a/light/lightchain.go
+++ b/light/lightchain.go
@@ -91,6 +91,7 @@ func NewLightChain(odr OdrBackend, config *params.ChainConfig, engine consensus.
 	if err != nil {
 		return nil, err
 	}
+
 	bc.genesisBlock, _ = bc.GetBlockByNumber(NoOdr, 0)
 	if bc.genesisBlock == nil {
 		return nil, core.ErrNoGenesis
@@ -111,6 +112,13 @@ func NewLightChain(odr OdrBackend, config *params.ChainConfig, engine consensus.
 		}
 	}
 	return bc, nil
+}
+
+func (self *LightChain) AddTrustedCheckpoint(name string, sectionIdx uint64,
+	sectionHead common.Hash,
+	chtRoot common.Hash, bloomTrieRoot common.Hash) {
+	cp := trustedCheckpoint{name, sectionIdx, sectionHead, chtRoot, bloomTrieRoot}
+	self.addTrustedCheckpoint(cp)
 }
 
 // addTrustedCheckpoint adds a trusted checkpoint to the blockchain

--- a/light/odr.go
+++ b/light/odr.go
@@ -169,3 +169,16 @@ func (req *BloomRequest) StoreResult(db ethdb.Database) {
 		core.WriteBloomBits(db, req.BitIdx, sectionIdx, sectionHead, req.BloomBits[i])
 	}
 }
+
+// CheckpointRequest is the ODR request type for retrieving a CHT+BloomRoot checkpoint
+type CheckpointRequest struct {
+	OdrRequest
+	SectionIdx  uint64
+	SectionHead common.Hash
+	ChtRoot     common.Hash
+	BloomRoot   common.Hash
+}
+
+// StoreResult stores the retrieved data in local database
+func (req *CheckpointRequest) StoreResult(db ethdb.Database) {
+}


### PR DESCRIPTION
(PR is against own fork's master for preliminary review.)

This PR addresses status.im issue 320: "Devise how to update CHT automatically"  https://github.com/status-im/status-go/issues/320

It supersedes PR https://github.com/status-im/status-go/pull/476

Add a GetCheckpoint request/response pair to LES, to allow client to retrieve an up-to-date checkpoint from peer before synching.
Tested and appears to work fine.
